### PR TITLE
Added more stringent consensus policy

### DIFF
--- a/ARTICLE-3.markdown
+++ b/ARTICLE-3.markdown
@@ -30,7 +30,7 @@ If it appears that consensus may not be reached in time for the decision to be t
 
 The decision should be made by Condorcet Vote, followed by discussion and if necessary, re-vote in case of a tie.
 
-In the case that the need for a decision is iminent and after 24 hours following the calling of a membership decision process vote there is no conclusive result, the Guiding Council shall have the option of taking on the decision, though they will offer the membership and explanation for this course of action. This stipulation does not apply to amendments or changes to these bylaws, which must always be ratified by the full membership.
+In the case that the need for a decision is iminent and after 24 hours following the calling of a membership decision process vote there is no conclusive result, the Guiding Council shall have the option of taking on the decision, though they must offer the membership and apology upon taking action, which shall include an explanation of the need for proceeding without member ratification and steps taken to ensure any demonstrated concerns of membership were taken into account. This stipulation does not apply to amendments or changes to these bylaws, which must always be ratified by the full membership.
 
 ### Section 3.3  Use of ballots for voting in case consensus is not reached
 


### PR DESCRIPTION
I am concerned that the current consensus process effectively eliminates the ability of members to block decisions that they have profound concerns regarding, effectively allowing any motivated block to proceed with a divisive decision based on timeliness.

I've added additional processes to allow for a clear process in the case of an unresolvable block.

Note that I have chosen to include dissolution of the cooperative as an explicit outcome. If an issue should be so egregious that a plurality if the membership feels it would be preferable to disolve than to either not act or act without consensus on the issue, than that may be what happens.

@brodavi I'd be interested in you adding language for specific ranked voting process, if you're open.

I know this is not maximally simple, but I hope it is clear and fair, and true to the spirit of consensus.
