### PR TITLE
Proposed formal council/board entity.

### DIFF
--- a/ARTICLE-3.markdown
+++ b/ARTICLE-3.markdown
@@ -70,7 +70,9 @@ council meeting.
 The council shall be responsible for decisions regarding allocation of funds,
 hiring of new resources, acceptance of new clients, strategic, marketing and
 branding decisions, and other governance and operational tasks not explicitly
-reserved by the membership.
+reserved by the membership or delegated to a working group. The council shall
+work to include all substantially impacted members in all decision making 
+processes.
 
 The council shall be formed at least annually. All members interested in participating 
 in council shall consense on a set of members to be put before the membership for


### PR DESCRIPTION
This is an initial attempt to establish a formal Guidance Council (e.g. "Board") entity in our bylaws.

It feels important to clarify the structure and intent of the council at the bylaws level, as our current structure invests quite heavily in council meetings and the council plays a critical role in the strategic, governance and operational oversight of the cooperative.

It has been noted that not members wish to partake in the coop at this level, and I personally feel that it is important that a group of members commit to regularly participating in council meetings, and that we establish the practice of monthly council meetings in the bylaws.

With that framework established, I have tried to craft language that follows the spirit of our discussions of these matters and compromises reached to date:

Re: @sapraaman's concerns about competitive elections, this proposal specifies a process wherein the council self-selects as a group, uses internal consensus to agree to its membership, then the entire coop membership ratifies the proposed group via the member consensus process.

Re: @brodavi's desire for as inclusive and non-exclusive a council as possible, this proposal includes open meetings in which all members are invited to participate, and has language to encourage frequent rotation on and off the council (something I believe is important for organizational resiliency and diversity).

I will hold off on proposing this as is for 24 hours and ask that all review the edit and comment on this thread if they feel any edits are required for them to support, or if they feel able to support as is.

Thanks.
